### PR TITLE
Fix `baseUrl` example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ The `createOAuthAppAuth` method accepts a single parameter with two keys
         <code>function</code>
       </th>
       <td>
-        You can pass in your own <a href="https://github.com/octokit/request.js"><code>@octokit/request</code></a> instance. For usage with enterprise, set <code>baseUrl</code> to the hostname. Example:
+        You can pass in your own <a href="https://github.com/octokit/request.js"><code>@octokit/request</code></a> instance. For usage with enterprise, set <code>baseUrl</code> to the API root endpoint. Example:
 
 ```js
 const { request } = require("@octokit/request");
@@ -181,7 +181,7 @@ createOAuthAppAuth({
   clientId: 123,
   clientSecret: "secret",
   request: request.defaults({
-    baseUrl: "https://ghe.my-company.com"
+    baseUrl: "https://ghe.my-company.com/api/v3"
   })
 });
 ```


### PR DESCRIPTION
The API root endpoint on GitHub Enterprise is [different from the public GitHub](https://developer.github.com/enterprise/2.20/v3/#root-endpoint) - actually, you already know 🙂, and you account for this in your code:

https://github.com/octokit/auth-oauth-app.js/blob/master/src/get-oauth-access-token.ts#L35

The README, however, suggested setting a custom `baseUrl` to the hostname of a GHE instance, which wouldn't work (line 35, linked above, would return the wrong route).

In short, this is just a documentation fix. Once I figured this out, the rest went smoothly, so... thanks for this library! 👍 