### PR TITLE
fix(pkg): add `main` entry point

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -74,6 +74,8 @@ async function main() {
       {
         ...pkg,
         files: ["dist-*/**", "bin/**"],
+        main: "./dist-node/index.js",
+        types: "./dist-types/index.d.ts",
         exports: {
           ".": {
             node: {


### PR DESCRIPTION
Some tools don't play well with only having the `exports` field present.

See octokit/core.js#662
