### PR TITLE
fix(deps): bump Octokit deps to fix Deno compat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-oauth-device": "^7.1.2",
-        "@octokit/auth-oauth-user": "^5.1.1",
+        "@octokit/auth-oauth-user": "^5.1.2",
         "@octokit/request": "^9.1.4",
         "@octokit/types": "^13.6.2",
         "universal-user-agent": "^7.0.0"
@@ -1469,15 +1469,15 @@
       }
     },
     "node_modules/@octokit/auth-oauth-user": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-5.1.1.tgz",
-      "integrity": "sha512-rRkMz0ErOppdvEfnemHJXgZ9vTPhBuC6yASeFaB7I2yLMd7QpjfrL1mnvRPlyKo+M6eeLxrKanXJ9Qte29SRsw==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-user/-/auth-oauth-user-5.1.2.tgz",
+      "integrity": "sha512-PgVDDPJgZYb3qSEXK4moksA23tfn68zwSAsQKZ1uH6IV9IaNEYx35OXXI80STQaLYnmEE86AgU0tC1YkM4WjsA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-oauth-device": "^7.0.1",
-        "@octokit/oauth-methods": "^5.0.0",
-        "@octokit/request": "^9.0.1",
-        "@octokit/types": "^13.0.0",
+        "@octokit/auth-oauth-device": "^7.1.2",
+        "@octokit/oauth-methods": "^5.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,14 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-oauth-device": "^7.0.0",
-        "@octokit/auth-oauth-user": "^5.0.1",
-        "@octokit/request": "^9.0.0",
-        "@octokit/types": "^13.0.0",
+        "@octokit/auth-oauth-device": "^7.1.2",
+        "@octokit/auth-oauth-user": "^5.1.1",
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
         "universal-user-agent": "^7.0.0"
       },
       "devDependencies": {
-        "@octokit/core": "^6.0.0",
+        "@octokit/core": "^6.1.3",
         "@octokit/tsconfig": "^4.0.0",
         "@types/fetch-mock": "^7.3.1",
         "@types/jest": "^29.0.0",
@@ -1454,14 +1454,14 @@
       }
     },
     "node_modules/@octokit/auth-oauth-device": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-7.1.1.tgz",
-      "integrity": "sha512-HWl8lYueHonuyjrKKIup/1tiy0xcmQCdq5ikvMO1YwkNNkxb6DXfrPjrMYItNLyCP/o2H87WuijuE+SlBTT8eg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-oauth-device/-/auth-oauth-device-7.1.2.tgz",
+      "integrity": "sha512-gTOIzDeV36OhVfxCl69FmvJix7tJIiU6dlxuzLVAzle7fYfO8UDyddr9B+o4CFQVaMBLMGZ9ak2CWMYcGeZnPw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/oauth-methods": "^5.0.0",
-        "@octokit/request": "^9.0.0",
-        "@octokit/types": "^13.0.0",
+        "@octokit/oauth-methods": "^5.1.3",
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
@@ -1495,17 +1495,17 @@
       }
     },
     "node_modules/@octokit/core": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
-      "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.3.tgz",
+      "integrity": "sha512-z+j7DixNnfpdToYsOutStDgeRzJSMnbj8T1C/oQjB6Aa+kRfNjs/Fn7W6c8bmlt6mfy3FkgeKBRnDjxQow5dow==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^5.0.0",
-        "@octokit/graphql": "^8.0.0",
-        "@octokit/request": "^9.0.0",
-        "@octokit/request-error": "^6.0.1",
-        "@octokit/types": "^13.0.0",
+        "@octokit/graphql": "^8.1.2",
+        "@octokit/request": "^9.1.4",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2",
         "before-after-hook": "^3.0.2",
         "universal-user-agent": "^7.0.0"
       },
@@ -1527,14 +1527,14 @@
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
-      "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.2.tgz",
+      "integrity": "sha512-bdlj/CJVjpaz06NBpfHhp4kGJaRZfz7AzC+6EwUImRtrwIw8dIgJ63Xg0OzV9pRn3rIzrt5c2sa++BL0JJ8GLw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@octokit/request": "^9.0.0",
-        "@octokit/types": "^13.0.0",
+        "@octokit/request": "^9.1.4",
+        "@octokit/types": "^13.6.2",
         "universal-user-agent": "^7.0.0"
       },
       "engines": {
@@ -1551,15 +1551,15 @@
       }
     },
     "node_modules/@octokit/oauth-methods": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-5.1.2.tgz",
-      "integrity": "sha512-C5lglRD+sBlbrhCUTxgJAFjWgJlmTx5bQ7Ch0+2uqRjYv7Cfb5xpX4WuSC9UgQna3sqRGBL9EImX9PvTpMaQ7g==",
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/oauth-methods/-/oauth-methods-5.1.3.tgz",
+      "integrity": "sha512-M+bDBi5H8FnH0xhCTg0m9hvcnppdDnxUqbZyOkxlLblKpLAR+eT2nbDPvJDp0eLrvJWA1I8OX0KHf/sBMQARRA==",
       "license": "MIT",
       "dependencies": {
         "@octokit/oauth-authorization-url": "^7.0.0",
-        "@octokit/request": "^9.1.0",
-        "@octokit/request-error": "^6.1.0",
-        "@octokit/types": "^13.0.0"
+        "@octokit/request": "^9.1.4",
+        "@octokit/request-error": "^6.1.6",
+        "@octokit/types": "^13.6.2"
       },
       "engines": {
         "node": ">= 18"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "MIT",
   "dependencies": {
     "@octokit/auth-oauth-device": "^7.1.2",
-    "@octokit/auth-oauth-user": "^5.1.1",
+    "@octokit/auth-oauth-user": "^5.1.2",
     "@octokit/request": "^9.1.4",
     "@octokit/types": "^13.6.2",
     "universal-user-agent": "^7.0.0"

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
   "author": "Gregor Martynus (https://github.com/gr2m)",
   "license": "MIT",
   "dependencies": {
-    "@octokit/auth-oauth-device": "^7.0.0",
-    "@octokit/auth-oauth-user": "^5.0.1",
-    "@octokit/request": "^9.0.0",
-    "@octokit/types": "^13.0.0",
+    "@octokit/auth-oauth-device": "^7.1.2",
+    "@octokit/auth-oauth-user": "^5.1.1",
+    "@octokit/request": "^9.1.4",
+    "@octokit/types": "^13.6.2",
     "universal-user-agent": "^7.0.0"
   },
   "devDependencies": {
-    "@octokit/core": "^6.0.0",
+    "@octokit/core": "^6.1.3",
     "@octokit/tsconfig": "^4.0.0",
     "@types/fetch-mock": "^7.3.1",
     "@types/jest": "^29.0.0",


### PR DESCRIPTION
See https://github.com/octokit/octokit.js/issues/2762#issuecomment-2486997620

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Types would include a reference to `@types/node` even though there is nothing using Node specific APIs in the types

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* Update `@octokit/types` to make sure types are platform agnostic
* Update all Octokit dependencies to their latest version to ensure we pull in the latest version of `@octokit/types`

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [x] No

----

